### PR TITLE
MAE-360 Fix contribute detail report query

### DIFF
--- a/CRM/Report/Form/Contribute/Detail.php
+++ b/CRM/Report/Form/Contribute/Detail.php
@@ -572,6 +572,7 @@ GROUP BY {$this->_aliases['civicrm_contribution']}.currency";
 
     // we inner join with temp1 to restrict soft contributions to those in temp1 table.
     // no group by here as we want to display as many soft credit rows as actually exist.
+    CRM_Utils_Hook::alterReportVar('sql', $this, $this);
     $sql = "{$select} {$this->_from} {$this->_where} $this->_groupBy";
     $this->createTemporaryTable('civireport_contribution_detail_temp2', $sql);
 

--- a/tests/phpunit/CRM/Report/Form/Contribute/DetailTest.php
+++ b/tests/phpunit/CRM/Report/Form/Contribute/DetailTest.php
@@ -253,4 +253,84 @@ class CRM_Report_Form_Contribute_DetailTest extends CiviReportTestCase {
 
   }
 
+  /**
+   * Make sure the civicrm_alterReportVar hook for contribute detail report work well.
+   * of soft credits.
+   */
+  public function testContributeDetailReportWithNewColumnFromCustomTable() {
+    $this->quickCleanup($this->_tablesToTruncate);
+
+    $solParams = [
+      'first_name' => 'Solicitor 1',
+      'last_name' => 'User ' . rand(),
+      'contact_type' => 'Individual',
+    ];
+    $solicitor1Id = $this->individualCreate($solParams);
+    $solParams['first_name'] = 'Solicitor 2';
+    $solicitor2Id = $this->individualCreate($solParams);
+    $solParams['first_name'] = 'Donor';
+    $donorId = $this->individualCreate($solParams);
+
+    $contribParams = [
+      'total_amount' => 150,
+      'contact_id' => $donorId,
+      // TODO: We're getting a "DB Error: already exists" when inserting a line
+      // item, but that's beside the point for this test, so skipping.
+      'skipLineItem' => 1,
+    ];
+    $contribId = $this->contributionCreate($contribParams);
+
+    $config = CRM_Core_Config::singleton();
+    CRM_Utils_File::sourceSQLFile($config->dsn, dirname(__FILE__) . "/fixtures/value_extension_tng55_table.sql");
+    CRM_Core_DAO::executeQuery("INSERT INTO civicrm_value_extension_tng55 (`entity_id`, `title`) VALUES (%1, 'some_title')", [1 => [$contribId, 'Positive']]);
+
+    CRM_Utils_Hook::singleton()->setHook('civicrm_alterReportVar', function ($varType, &$var, &$reportForm) {
+      if ($varType === 'columns') {
+        $var['civicrm_value_extension_tng55'] = [
+          'fields' => [
+            'extension_tng55_title' => [
+              'title' => ts('Extension Title'),
+              'dbAlias' => "civicrm_value_extension_tng55.title",
+            ],
+          ],
+          'filters' => [
+            'extension_tng55_title' => [
+              'title' => ts('Extension Title'),
+              'dbAlias' => "civicrm_value_extension_tng55.title",
+              'type' => CRM_Utils_Type::T_INT,
+              'operatorType' => CRM_Report_Form::OP_MULTISELECT,
+              'options' => [],
+            ],
+          ],
+        ];
+      }
+      if ($varType === 'sql') {
+        $from = $var->getVar('_from');
+        $from .= "
+            LEFT JOIN civicrm_value_extension_tng55
+            ON (civicrm_value_extension_tng55.entity_id = contribution_civireport.id)
+        ";
+        $var->setVar('_from', $from);
+      }
+    });
+
+    $input = [
+      'extension_tng55_title_op' => 'nnll',
+      'fields' => [
+        'sort_name' => 1,
+        'contribution_id' => 1,
+        'total_amount' => 1,
+        'extension_tng55_title' => 1,
+      ],
+    ];
+    $params = array_merge([
+      'report_id' => 'contribute/detail',
+    ], $input);
+    $rows = $this->callAPISuccess('ReportTemplate', 'getrows', $params)['values'];
+
+    $this->assertCount(1, $rows);
+    $this->assertEquals('some_title', $rows[0]['civicrm_value_extension_tng55_extension_tng55_title']);
+
+  }
+
 }

--- a/tests/phpunit/CRM/Report/Form/Contribute/fixtures/value_extension_tng55_table.sql
+++ b/tests/phpunit/CRM/Report/Form/Contribute/fixtures/value_extension_tng55_table.sql
@@ -1,0 +1,26 @@
+-- phpMyAdmin SQL Dump
+-- version 4.9.7
+-- https://www.phpmyadmin.net/
+--
+-- Host: 127.0.0.1
+-- Generation Time: Jan 04, 2021 at 06:30 AM
+-- Server version: 5.7.32
+-- PHP Version: 7.4.3
+
+SET SQL_MODE="NO_AUTO_VALUE_ON_ZERO";
+SET FOREIGN_KEY_CHECKS=0;
+
+--
+-- Database: `civicrm_tests_dev`
+--
+
+--
+-- Dumping data for table `civicrm_value_extension_tng55`
+--
+
+CREATE TABLE `civicrm_value_extension_tng55` (
+  `id` int(10) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'Default MySQL primary key',
+  `entity_id` int(10) UNSIGNED NOT NULL,
+  `title` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;


### PR DESCRIPTION
Overview
----------------------------------------
The `civicrm_alterReportVar` is not working for contribute detail report.

Before
----------------------------------------
We're getting a "DB Error: no such field" when using the hook.

After
----------------------------------------
No Errors.

Technical Details
----------------------------------------

Here at [Detail.php#L956](https://github.com/civicrm/civicrm-core/blob/3662d5a75d79d6c259b632df748b1beb66db6faf/CRM/Report/Form/Contribute/Detail.php#L956) our changes to the `_form` attribute are lost and the error will be fired here [Detail.php#L576](https://github.com/civicrm/civicrm-core/blob/3662d5a75d79d6c259b632df748b1beb66db6faf/CRM/Report/Form/Contribute/Detail.php#L576)  

    Unknown column 'some_table.some_column' in 'where clause'


Comments
----------------------------------------
Adds test cover
